### PR TITLE
Add basic REST controllers

### DIFF
--- a/WebAPI/Controllers/AccountController.cs
+++ b/WebAPI/Controllers/AccountController.cs
@@ -1,0 +1,68 @@
+using BusinessObjects.Identity;
+using DTOs.UserDTOs.Request;
+using DTOs.UserDTOs.Response;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Services.Interfaces;
+using WebAPI.Middlewares;
+
+namespace WebAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class AccountController : ControllerBase
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly SignInManager<ApplicationUser> _signInManager;
+        private readonly ITokenService _tokenService;
+
+        public AccountController(
+            UserManager<ApplicationUser> userManager,
+            SignInManager<ApplicationUser> signInManager,
+            ITokenService tokenService)
+        {
+            _userManager = userManager;
+            _signInManager = signInManager;
+            _tokenService = tokenService;
+        }
+
+        [HttpPost("register")]
+        [ServiceFilter(typeof(ValidateModelAttribute))]
+        public async Task<IActionResult> Register([FromBody] UserRegisterRequestDTO request)
+        {
+            var user = new ApplicationUser
+            {
+                UserName = request.Email,
+                Email = request.Email,
+                FirstName = request.FirstName,
+                LastName = request.LastName,
+                Gender = request.Gender
+            };
+
+            var result = await _userManager.CreateAsync(user, request.Password);
+            if (!result.Succeeded)
+            {
+                return BadRequest(result.Errors);
+            }
+
+            await _userManager.AddToRoleAsync(user, "Customer");
+            return Ok(new { user.Id, user.Email });
+        }
+
+        [HttpPost("login")]
+        [ServiceFilter(typeof(ValidateModelAttribute))]
+        public async Task<IActionResult> Login([FromBody] UserLoginRequest request)
+        {
+            var user = await _userManager.FindByEmailAsync(request.Email);
+            if (user == null) return Unauthorized();
+
+            var result = await _signInManager.CheckPasswordSignInAsync(user, request.Password, false);
+            if (!result.Succeeded) return Unauthorized();
+
+            var tokenResult = await _tokenService.GenerateToken(user);
+            if (!tokenResult.IsSuccess) return StatusCode(500, tokenResult.Message);
+
+            return Ok(new LoginResponse(tokenResult.Data!));
+        }
+    }
+}

--- a/WebAPI/Controllers/CartItemsController.cs
+++ b/WebAPI/Controllers/CartItemsController.cs
@@ -1,0 +1,57 @@
+using BusinessObjects.Cart;
+using Microsoft.AspNetCore.Mvc;
+using Repositories.WorkSeeds.Interfaces;
+using WebAPI.Middlewares;
+
+namespace WebAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class CartItemsController : ControllerBase
+    {
+        private readonly IUnitOfWork _unitOfWork;
+
+        public CartItemsController(IUnitOfWork unitOfWork)
+        {
+            _unitOfWork = unitOfWork;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Get()
+        {
+            var repo = _unitOfWork.GetRepository<CartItem, Guid>();
+            var items = await repo.GetAllAsync();
+            return Ok(items);
+        }
+
+        [HttpPost]
+        [ServiceFilter(typeof(ValidateModelAttribute))]
+        public async Task<IActionResult> Post([FromBody] CartItem item)
+        {
+            var repo = _unitOfWork.GetRepository<CartItem, Guid>();
+            await repo.AddAsync(item);
+            await _unitOfWork.SaveChangesAsync();
+            return CreatedAtAction(nameof(Get), new { id = item.Id }, item);
+        }
+
+        [HttpPut("{id}")]
+        [ServiceFilter(typeof(ValidateModelAttribute))]
+        public async Task<IActionResult> Put(Guid id, [FromBody] CartItem item)
+        {
+            if (id != item.Id) return BadRequest();
+            var repo = _unitOfWork.GetRepository<CartItem, Guid>();
+            await repo.UpdateAsync(item);
+            await _unitOfWork.SaveChangesAsync();
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(Guid id)
+        {
+            var repo = _unitOfWork.GetRepository<CartItem, Guid>();
+            await repo.DeleteAsync(id);
+            await _unitOfWork.SaveChangesAsync();
+            return NoContent();
+        }
+    }
+}

--- a/WebAPI/Controllers/CategoriesController.cs
+++ b/WebAPI/Controllers/CategoriesController.cs
@@ -1,0 +1,66 @@
+using BusinessObjects.Products;
+using Microsoft.AspNetCore.Mvc;
+using Repositories.WorkSeeds.Interfaces;
+using WebAPI.Middlewares;
+
+namespace WebAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class CategoriesController : ControllerBase
+    {
+        private readonly IUnitOfWork _unitOfWork;
+
+        public CategoriesController(IUnitOfWork unitOfWork)
+        {
+            _unitOfWork = unitOfWork;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Get()
+        {
+            var repo = _unitOfWork.GetRepository<Category, Guid>();
+            var items = await repo.GetAllAsync();
+            return Ok(items);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> Get(Guid id)
+        {
+            var repo = _unitOfWork.GetRepository<Category, Guid>();
+            var item = await repo.GetByIdAsync(id);
+            if (item == null) return NotFound();
+            return Ok(item);
+        }
+
+        [HttpPost]
+        [ServiceFilter(typeof(ValidateModelAttribute))]
+        public async Task<IActionResult> Post([FromBody] Category category)
+        {
+            var repo = _unitOfWork.GetRepository<Category, Guid>();
+            await repo.AddAsync(category);
+            await _unitOfWork.SaveChangesAsync();
+            return CreatedAtAction(nameof(Get), new { id = category.Id }, category);
+        }
+
+        [HttpPut("{id}")]
+        [ServiceFilter(typeof(ValidateModelAttribute))]
+        public async Task<IActionResult> Put(Guid id, [FromBody] Category category)
+        {
+            if (id != category.Id) return BadRequest();
+            var repo = _unitOfWork.GetRepository<Category, Guid>();
+            await repo.UpdateAsync(category);
+            await _unitOfWork.SaveChangesAsync();
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(Guid id)
+        {
+            var repo = _unitOfWork.GetRepository<Category, Guid>();
+            await repo.SoftDeleteAsync(id);
+            await _unitOfWork.SaveChangesAsync();
+            return NoContent();
+        }
+    }
+}

--- a/WebAPI/Controllers/CouponsController.cs
+++ b/WebAPI/Controllers/CouponsController.cs
@@ -1,0 +1,57 @@
+using BusinessObjects.Coupons;
+using Microsoft.AspNetCore.Mvc;
+using Repositories.WorkSeeds.Interfaces;
+using WebAPI.Middlewares;
+
+namespace WebAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class CouponsController : ControllerBase
+    {
+        private readonly IUnitOfWork _unitOfWork;
+
+        public CouponsController(IUnitOfWork unitOfWork)
+        {
+            _unitOfWork = unitOfWork;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Get()
+        {
+            var repo = _unitOfWork.GetRepository<Coupon, Guid>();
+            var items = await repo.GetAllAsync();
+            return Ok(items);
+        }
+
+        [HttpPost]
+        [ServiceFilter(typeof(ValidateModelAttribute))]
+        public async Task<IActionResult> Post([FromBody] Coupon coupon)
+        {
+            var repo = _unitOfWork.GetRepository<Coupon, Guid>();
+            await repo.AddAsync(coupon);
+            await _unitOfWork.SaveChangesAsync();
+            return CreatedAtAction(nameof(Get), new { id = coupon.Id }, coupon);
+        }
+
+        [HttpPut("{id}")]
+        [ServiceFilter(typeof(ValidateModelAttribute))]
+        public async Task<IActionResult> Put(Guid id, [FromBody] Coupon coupon)
+        {
+            if (id != coupon.Id) return BadRequest();
+            var repo = _unitOfWork.GetRepository<Coupon, Guid>();
+            await repo.UpdateAsync(coupon);
+            await _unitOfWork.SaveChangesAsync();
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(Guid id)
+        {
+            var repo = _unitOfWork.GetRepository<Coupon, Guid>();
+            await repo.SoftDeleteAsync(id);
+            await _unitOfWork.SaveChangesAsync();
+            return NoContent();
+        }
+    }
+}

--- a/WebAPI/Controllers/CustomDesignsController.cs
+++ b/WebAPI/Controllers/CustomDesignsController.cs
@@ -1,0 +1,66 @@
+using BusinessObjects.CustomDesigns;
+using Microsoft.AspNetCore.Mvc;
+using Repositories.WorkSeeds.Interfaces;
+using WebAPI.Middlewares;
+
+namespace WebAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class CustomDesignsController : ControllerBase
+    {
+        private readonly IUnitOfWork _unitOfWork;
+
+        public CustomDesignsController(IUnitOfWork unitOfWork)
+        {
+            _unitOfWork = unitOfWork;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Get()
+        {
+            var repo = _unitOfWork.GetRepository<CustomDesign, Guid>();
+            var items = await repo.GetAllAsync();
+            return Ok(items);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> Get(Guid id)
+        {
+            var repo = _unitOfWork.GetRepository<CustomDesign, Guid>();
+            var item = await repo.GetByIdAsync(id);
+            if (item == null) return NotFound();
+            return Ok(item);
+        }
+
+        [HttpPost]
+        [ServiceFilter(typeof(ValidateModelAttribute))]
+        public async Task<IActionResult> Post([FromBody] CustomDesign design)
+        {
+            var repo = _unitOfWork.GetRepository<CustomDesign, Guid>();
+            await repo.AddAsync(design);
+            await _unitOfWork.SaveChangesAsync();
+            return CreatedAtAction(nameof(Get), new { id = design.Id }, design);
+        }
+
+        [HttpPut("{id}")]
+        [ServiceFilter(typeof(ValidateModelAttribute))]
+        public async Task<IActionResult> Put(Guid id, [FromBody] CustomDesign design)
+        {
+            if (id != design.Id) return BadRequest();
+            var repo = _unitOfWork.GetRepository<CustomDesign, Guid>();
+            await repo.UpdateAsync(design);
+            await _unitOfWork.SaveChangesAsync();
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(Guid id)
+        {
+            var repo = _unitOfWork.GetRepository<CustomDesign, Guid>();
+            await repo.SoftDeleteAsync(id);
+            await _unitOfWork.SaveChangesAsync();
+            return NoContent();
+        }
+    }
+}

--- a/WebAPI/Controllers/OrdersController.cs
+++ b/WebAPI/Controllers/OrdersController.cs
@@ -1,0 +1,66 @@
+using BusinessObjects.Orders;
+using Microsoft.AspNetCore.Mvc;
+using Repositories.WorkSeeds.Interfaces;
+using WebAPI.Middlewares;
+
+namespace WebAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class OrdersController : ControllerBase
+    {
+        private readonly IUnitOfWork _unitOfWork;
+
+        public OrdersController(IUnitOfWork unitOfWork)
+        {
+            _unitOfWork = unitOfWork;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Get()
+        {
+            var repo = _unitOfWork.GetRepository<Order, Guid>();
+            var items = await repo.GetAllAsync();
+            return Ok(items);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> Get(Guid id)
+        {
+            var repo = _unitOfWork.GetRepository<Order, Guid>();
+            var item = await repo.GetByIdAsync(id);
+            if (item == null) return NotFound();
+            return Ok(item);
+        }
+
+        [HttpPost]
+        [ServiceFilter(typeof(ValidateModelAttribute))]
+        public async Task<IActionResult> Post([FromBody] Order order)
+        {
+            var repo = _unitOfWork.GetRepository<Order, Guid>();
+            await repo.AddAsync(order);
+            await _unitOfWork.SaveChangesAsync();
+            return CreatedAtAction(nameof(Get), new { id = order.Id }, order);
+        }
+
+        [HttpPut("{id}")]
+        [ServiceFilter(typeof(ValidateModelAttribute))]
+        public async Task<IActionResult> Put(Guid id, [FromBody] Order order)
+        {
+            if (id != order.Id) return BadRequest();
+            var repo = _unitOfWork.GetRepository<Order, Guid>();
+            await repo.UpdateAsync(order);
+            await _unitOfWork.SaveChangesAsync();
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(Guid id)
+        {
+            var repo = _unitOfWork.GetRepository<Order, Guid>();
+            await repo.SoftDeleteAsync(id);
+            await _unitOfWork.SaveChangesAsync();
+            return NoContent();
+        }
+    }
+}

--- a/WebAPI/Controllers/PaymentsController.cs
+++ b/WebAPI/Controllers/PaymentsController.cs
@@ -1,0 +1,37 @@
+using BusinessObjects.Entities.Payments;
+using Microsoft.AspNetCore.Mvc;
+using Repositories.WorkSeeds.Interfaces;
+using WebAPI.Middlewares;
+
+namespace WebAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class PaymentsController : ControllerBase
+    {
+        private readonly IUnitOfWork _unitOfWork;
+
+        public PaymentsController(IUnitOfWork unitOfWork)
+        {
+            _unitOfWork = unitOfWork;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Get()
+        {
+            var repo = _unitOfWork.GetRepository<Payment, Guid>();
+            var items = await repo.GetAllAsync();
+            return Ok(items);
+        }
+
+        [HttpPost]
+        [ServiceFilter(typeof(ValidateModelAttribute))]
+        public async Task<IActionResult> Post([FromBody] Payment payment)
+        {
+            var repo = _unitOfWork.GetRepository<Payment, Guid>();
+            await repo.AddAsync(payment);
+            await _unitOfWork.SaveChangesAsync();
+            return CreatedAtAction(nameof(Get), new { id = payment.Id }, payment);
+        }
+    }
+}

--- a/WebAPI/Controllers/ProductsController.cs
+++ b/WebAPI/Controllers/ProductsController.cs
@@ -1,0 +1,66 @@
+using BusinessObjects.Products;
+using Microsoft.AspNetCore.Mvc;
+using Repositories.WorkSeeds.Interfaces;
+using WebAPI.Middlewares;
+
+namespace WebAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class ProductsController : ControllerBase
+    {
+        private readonly IUnitOfWork _unitOfWork;
+
+        public ProductsController(IUnitOfWork unitOfWork)
+        {
+            _unitOfWork = unitOfWork;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Get()
+        {
+            var repo = _unitOfWork.GetRepository<Product, Guid>();
+            var items = await repo.GetAllAsync();
+            return Ok(items);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> Get(Guid id)
+        {
+            var repo = _unitOfWork.GetRepository<Product, Guid>();
+            var item = await repo.GetByIdAsync(id);
+            if (item == null) return NotFound();
+            return Ok(item);
+        }
+
+        [HttpPost]
+        [ServiceFilter(typeof(ValidateModelAttribute))]
+        public async Task<IActionResult> Post([FromBody] Product product)
+        {
+            var repo = _unitOfWork.GetRepository<Product, Guid>();
+            await repo.AddAsync(product);
+            await _unitOfWork.SaveChangesAsync();
+            return CreatedAtAction(nameof(Get), new { id = product.Id }, product);
+        }
+
+        [HttpPut("{id}")]
+        [ServiceFilter(typeof(ValidateModelAttribute))]
+        public async Task<IActionResult> Put(Guid id, [FromBody] Product product)
+        {
+            if (id != product.Id) return BadRequest();
+            var repo = _unitOfWork.GetRepository<Product, Guid>();
+            await repo.UpdateAsync(product);
+            await _unitOfWork.SaveChangesAsync();
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(Guid id)
+        {
+            var repo = _unitOfWork.GetRepository<Product, Guid>();
+            await repo.SoftDeleteAsync(id);
+            await _unitOfWork.SaveChangesAsync();
+            return NoContent();
+        }
+    }
+}

--- a/WebAPI/Controllers/ReviewsController.cs
+++ b/WebAPI/Controllers/ReviewsController.cs
@@ -1,0 +1,57 @@
+using BusinessObjects.Reviews;
+using Microsoft.AspNetCore.Mvc;
+using Repositories.WorkSeeds.Interfaces;
+using WebAPI.Middlewares;
+
+namespace WebAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class ReviewsController : ControllerBase
+    {
+        private readonly IUnitOfWork _unitOfWork;
+
+        public ReviewsController(IUnitOfWork unitOfWork)
+        {
+            _unitOfWork = unitOfWork;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Get()
+        {
+            var repo = _unitOfWork.GetRepository<Review, Guid>();
+            var items = await repo.GetAllAsync();
+            return Ok(items);
+        }
+
+        [HttpPost]
+        [ServiceFilter(typeof(ValidateModelAttribute))]
+        public async Task<IActionResult> Post([FromBody] Review review)
+        {
+            var repo = _unitOfWork.GetRepository<Review, Guid>();
+            await repo.AddAsync(review);
+            await _unitOfWork.SaveChangesAsync();
+            return CreatedAtAction(nameof(Get), new { id = review.Id }, review);
+        }
+
+        [HttpPut("{id}")]
+        [ServiceFilter(typeof(ValidateModelAttribute))]
+        public async Task<IActionResult> Put(Guid id, [FromBody] Review review)
+        {
+            if (id != review.Id) return BadRequest();
+            var repo = _unitOfWork.GetRepository<Review, Guid>();
+            await repo.UpdateAsync(review);
+            await _unitOfWork.SaveChangesAsync();
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(Guid id)
+        {
+            var repo = _unitOfWork.GetRepository<Review, Guid>();
+            await repo.SoftDeleteAsync(id);
+            await _unitOfWork.SaveChangesAsync();
+            return NoContent();
+        }
+    }
+}

--- a/WebAPI/Controllers/ShippingMethodsController.cs
+++ b/WebAPI/Controllers/ShippingMethodsController.cs
@@ -1,0 +1,57 @@
+using BusinessObjects.Shipping;
+using Microsoft.AspNetCore.Mvc;
+using Repositories.WorkSeeds.Interfaces;
+using WebAPI.Middlewares;
+
+namespace WebAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class ShippingMethodsController : ControllerBase
+    {
+        private readonly IUnitOfWork _unitOfWork;
+
+        public ShippingMethodsController(IUnitOfWork unitOfWork)
+        {
+            _unitOfWork = unitOfWork;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Get()
+        {
+            var repo = _unitOfWork.GetRepository<ShippingMethod, Guid>();
+            var items = await repo.GetAllAsync();
+            return Ok(items);
+        }
+
+        [HttpPost]
+        [ServiceFilter(typeof(ValidateModelAttribute))]
+        public async Task<IActionResult> Post([FromBody] ShippingMethod method)
+        {
+            var repo = _unitOfWork.GetRepository<ShippingMethod, Guid>();
+            await repo.AddAsync(method);
+            await _unitOfWork.SaveChangesAsync();
+            return CreatedAtAction(nameof(Get), new { id = method.Id }, method);
+        }
+
+        [HttpPut("{id}")]
+        [ServiceFilter(typeof(ValidateModelAttribute))]
+        public async Task<IActionResult> Put(Guid id, [FromBody] ShippingMethod method)
+        {
+            if (id != method.Id) return BadRequest();
+            var repo = _unitOfWork.GetRepository<ShippingMethod, Guid>();
+            await repo.UpdateAsync(method);
+            await _unitOfWork.SaveChangesAsync();
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(Guid id)
+        {
+            var repo = _unitOfWork.GetRepository<ShippingMethod, Guid>();
+            await repo.SoftDeleteAsync(id);
+            await _unitOfWork.SaveChangesAsync();
+            return NoContent();
+        }
+    }
+}

--- a/WebAPI/Controllers/WishlistController.cs
+++ b/WebAPI/Controllers/WishlistController.cs
@@ -1,0 +1,46 @@
+using BusinessObjects.Wishlists;
+using Microsoft.AspNetCore.Mvc;
+using Repositories.WorkSeeds.Interfaces;
+using WebAPI.Middlewares;
+
+namespace WebAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class WishlistController : ControllerBase
+    {
+        private readonly IUnitOfWork _unitOfWork;
+
+        public WishlistController(IUnitOfWork unitOfWork)
+        {
+            _unitOfWork = unitOfWork;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Get()
+        {
+            var repo = _unitOfWork.GetRepository<WishlistItem, Guid>();
+            var items = await repo.GetAllAsync();
+            return Ok(items);
+        }
+
+        [HttpPost]
+        [ServiceFilter(typeof(ValidateModelAttribute))]
+        public async Task<IActionResult> Post([FromBody] WishlistItem item)
+        {
+            var repo = _unitOfWork.GetRepository<WishlistItem, Guid>();
+            await repo.AddAsync(item);
+            await _unitOfWork.SaveChangesAsync();
+            return CreatedAtAction(nameof(Get), new { id = item.Id }, item);
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(Guid id)
+        {
+            var repo = _unitOfWork.GetRepository<WishlistItem, Guid>();
+            await repo.DeleteAsync(id);
+            await _unitOfWork.SaveChangesAsync();
+            return NoContent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement simple REST controllers for main entities: Account, Categories, Products, CustomDesigns, CartItems, Wishlist, Orders, ShippingMethods, Coupons, Reviews, and Payments
- controllers use `IUnitOfWork` and `ValidateModelAttribute`

## Testing
- `dotnet build WebAPI/WebAPI.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685275d78760832b8fd36ccf80cc9b51